### PR TITLE
fix(bug): music player replace playlists song after search_play

### DIFF
--- a/mr_robot/bot.py
+++ b/mr_robot/bot.py
@@ -9,7 +9,7 @@ from aiocache import cached
 from aiosqlite import Connection
 from disnake.ext import commands
 
-from mr_robot.constants import Client
+from mr_robot.constants import Client, Lavalink
 from mr_robot.utils.extensions import walk_extensions
 from mr_robot.utils.git_api import Git
 
@@ -61,10 +61,10 @@ class MrRobot(commands.AutoShardedInteractionBot):
             try:
                 await self.wait_until_ready()
                 await self.pool.create_node(
-                    host="lavalink",
-                    port=2333,
-                    label="MAIN",
-                    password="youshallnotpass",
+                    host=Lavalink.host,
+                    port=Lavalink.port,
+                    password=Lavalink.password,
+                    label=Lavalink.label,
                 )
                 break
             except Exception:

--- a/mr_robot/constants.py
+++ b/mr_robot/constants.py
@@ -21,6 +21,15 @@ class Client:
     logging_config_file = "logging_config.json"
 
 
+class Lavalink:
+    """Lavalink Player Constants"""
+
+    host = "lavalink"
+    port = 2333
+    label = "MAIN"
+    password = "youshallnotpass"
+
+
 class ButtonCustomId:
     """Button Custom Ids"""
 

--- a/mr_robot/exts/backend/error_handler.py
+++ b/mr_robot/exts/backend/error_handler.py
@@ -140,6 +140,8 @@ class ErrorHandler(commands.Cog, slash_command_attrs={"dm_permission": False}):
             ctx.send_error = partial(ctx.send, components=components)  # type: ignore[reportAttributeAccessIssue]
         elif isinstance(ctx, disnake.Interaction):
             if ctx.response.is_done():
+                components.insert_item(0, DeleteButton(ctx.author))
+            if ctx.response.is_done():
                 ctx.send_error = partial(ctx.followup.send, ephemeral=True, components=components)  # type: ignore[reportAttributeAccessIssue]
             else:
                 ctx.send_error = partial(ctx.send, ephemeral=True, components=components)  # type: ignore[reportAttributeAccessIssue]


### PR DESCRIPTION
Whenever music was player via `search` argument and during the song when play command was again invoked with `playlist_name` argument then a all playlist track was skipped and ended up playing last track in playlist.

Potential Reason: When such thing was performed then this might ends up with multiple track end event get dispatched (might be meta data fetching process end would be marked as track end)

Solution: Before popping track form queue in `on_track_end` handler, placing a check like `if event.player.reason == ReasonType.REPLACE: return` works